### PR TITLE
docs: add guide for using cv4pve-cli with AI coding assistants (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,12 @@ To force re-registration: `cv4pve-cli completion reset`
 
 ---
 
+## Using with AI coding assistants
+
+Tips for running `cv4pve-cli` inside Claude Code, Codex and similar sandboxed agents (self-signed certs, sandbox permissions, `SKILL.md` template): see [docs/AI-AGENTS.md](docs/AI-AGENTS.md).
+
+---
+
 ## Support
 
 Professional support available through [Corsinvest](https://www.corsinvest.it/cv4pve).

--- a/docs/AI-AGENTS.md
+++ b/docs/AI-AGENTS.md
@@ -1,0 +1,89 @@
+# Using cv4pve-cli with AI coding assistants
+
+`cv4pve-cli` works well as a tool for AI coding assistants (Claude Code, Codex, …) that need to interact with a Proxmox VE cluster. This page collects configuration tips for the most common sandboxes, plus a minimal `SKILL.md` template you can drop into a project.
+
+> Credit: most of the findings below come from [issue #10](https://github.com/Corsinvest/cv4pve-cli/issues/10) — thanks to [@cheriot](https://github.com/cheriot).
+
+---
+
+## Claude Code (macOS sandbox)
+
+If your Proxmox host uses a **self-signed certificate**, disabling certificate validation in `cv4pve-cli` (`--validate-certificate false` on the context) is not enough on macOS: the Claude Code sandbox blocks the Mach lookup that macOS performs internally for **every** HTTPS connection, even when the app skips verification. The connection will fail with an opaque error.
+
+Add the following to your `.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:$PROXMOX_IP)"
+    ]
+  },
+  "sandbox": {
+    "network": {
+      "allowMachLookup": ["com.apple.trustd*"]
+    },
+    "filesystem": {
+      "allowWrite": ["~/.cv4pve/"]
+    }
+  }
+}
+```
+
+What each entry does:
+
+| Entry | Purpose |
+|-------|---------|
+| `WebFetch(domain:$PROXMOX_IP)` | Allow outbound calls to the Proxmox host |
+| `allowMachLookup: ["com.apple.trustd*"]` | Allow macOS trust daemon lookup (required for HTTPS, even with cert validation off) |
+| `allowWrite: ["~/.cv4pve/"]` | Let cv4pve-cli persist contexts, aliases and API cache |
+
+---
+
+## Codex
+
+Codex needs an explicit allow rule for the binary. Add to `~/.codex/rules/default.rules`:
+
+```
+prefix_rule(pattern=["cv4pve-cli"], decision="allow")
+```
+
+Tighten the rule further if you want to restrict it to a specific context (e.g. a read-only auditor token).
+
+---
+
+## Suggested `SKILL.md` for a project
+
+A short `SKILL.md` describing the tool and a couple of canonical examples is often enough to make agents productive. Minimal template:
+
+```markdown
+# cv4pve-cli
+
+Remote-first CLI for Proxmox VE. Use it for any read or change against the
+Proxmox API instead of SSH-ing into a node.
+
+## Active context
+A context named `homelab` is already configured. Do **not** add or switch contexts.
+
+## Common commands
+- `cv4pve-cli top`                          — cluster resource overview
+- `cv4pve-cli get vms`                      — list all VMs
+- `cv4pve-cli show vm --guest <name|id>`    — show VM config
+- `cv4pve-cli api get <path>`               — raw API read
+- `cv4pve-cli api usage <path> [method]`    — discover parameters of an endpoint
+
+## Conventions
+- Prefer `--guest <name|id>` over typing `<node> <vmtype> <vmid>` by hand.
+- Use `--output json` when the result will be parsed.
+- Destructive aliases live under `do …` / `delete …` — confirm with the user first.
+```
+
+Adapt the active-context section to whatever token / role you provisioned (e.g. an auditor token for read-only work).
+
+---
+
+## Tips
+
+- **Read-only by default:** create a dedicated Proxmox API token with the `PVEAuditor` role and use it as the agent's context. The agent can still inspect everything but cannot modify state.
+- **Cache lives under `~/.cv4pve/`:** make sure the sandbox can write there, otherwise the API schema is re-fetched on every call.
+- **Tab completion is not useful inside an agent** — agents don't drive a TTY. Skip `completion reset` in the sandbox.


### PR DESCRIPTION
## Summary

Closes #10.

- Add `docs/AI-AGENTS.md` with sandbox configuration tips for AI coding assistants:
  - **Claude Code (macOS):** `allowMachLookup: ["com.apple.trustd*"]` to fix HTTPS connections to Proxmox hosts with self-signed certificates, plus the full `.claude/settings.json` snippet.
  - **Codex:** `prefix_rule(pattern=["cv4pve-cli"], decision="allow")` for `~/.codex/rules/default.rules`.
  - Minimal `SKILL.md` template to bootstrap an agent.
  - Tips on using a `PVEAuditor` token for read-only operations.
- Add a short pointer section in the README linking to the new doc.
- Normalize the README filename extension to lowercase (`README.MD` → `README.md`).

Credit to @cheriot for the findings reported in #10.

## Test plan

- [ ] Verify rendering of `docs/AI-AGENTS.md` on GitHub
- [ ] Verify the new "Using with AI coding assistants" section renders correctly in the README
- [ ] Confirm `README.md` is still picked up as the project landing page on GitHub