### PR TITLE
Add semantic exit codes and send errors to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ cv4pve-cli top
 - **Guest auto-resolution** — use `--guest <name|id>` instead of typing node, vmtype and vmid
 - **Tab completion** — bash, zsh and PowerShell, queries the live API
 - **API schema cached locally** — refreshed automatically on PVE upgrade
+- **Scriptable** — semantic [exit codes](docs/commands.md#exit-codes), errors on stderr
 
 | | [pvesh](https://pve.proxmox.com/pve-docs/pvesh.1.html) | kubectl | cv4pve-cli |
 |---|---|---|---|

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -19,6 +19,32 @@ Available on every command:
 
 ---
 
+## Exit codes
+
+Commands return a semantic exit code so scripts and CI can react to the failure kind. Error messages go to **stderr**; normal output stays on **stdout**.
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | Generic / unclassified error |
+| `2` | Authentication or configuration error |
+| `3` | Resource not found |
+| `4` | API / server error (unreachable, HTTP 5xx) |
+| `5` | Async task failed |
+| `6` | Input validation error |
+
+```bash
+cv4pve-cli config verify prod
+case $? in
+  0) echo "ok" ;;
+  2) echo "bad credentials" ;;
+  3) echo "context not found" ;;
+  4) echo "server unreachable" ;;
+esac
+```
+
+---
+
 ## config — connection profiles (contexts)
 
 A context stores host, credentials and port. All configuration lives under `~/.cv4pve/cli/` (`%USERPROFILE%\.cv4pve\cli\` on Windows) in editable YAML.

--- a/src/Corsinvest.ProxmoxVE.Cli/Config/AliasCommands.cs
+++ b/src/Corsinvest.ProxmoxVE.Cli/Config/AliasCommands.cs
@@ -101,8 +101,9 @@ internal static class AliasCommands
                                                                             action.GetValue(optDescription) ?? string.Empty,
                                                                             action.GetValue(optCommand)!));
                 Console.WriteLine($"Alias '{name}' added.");
+                return (int)ExitCode.Ok;
             }
-            catch (Exception ex) { Console.WriteLine($"Error: {ex.Message}"); }
+            catch (Exception ex) { return ExitCodeHelper.Fail(ex.Message, ExitCode.Validation); }
         });
     }
 
@@ -119,8 +120,9 @@ internal static class AliasCommands
                 if (PveConfigManager.IsBuiltinAlias(name)) { throw new InvalidOperationException($"'{name}' is a built-in alias and cannot be removed."); }
                 PveConfigManager.RemoveUserAlias(name);
                 Console.WriteLine($"Alias '{name}' removed.");
+                return (int)ExitCode.Ok;
             }
-            catch (Exception ex) { Console.WriteLine($"Error: {ex.Message}"); }
+            catch (Exception ex) { return ExitCodeHelper.Fail(ex.Message, ExitCode.Validation); }
         });
     }
 }

--- a/src/Corsinvest.ProxmoxVE.Cli/Config/ConfigCommands.cs
+++ b/src/Corsinvest.ProxmoxVE.Cli/Config/ConfigCommands.cs
@@ -14,16 +14,22 @@ namespace Corsinvest.ProxmoxVE.Cli.Config;
 /// </summary>
 internal static class ConfigCommands
 {
-    private static async Task ValidateAndPrint(PveContext ctx)
+    /// <summary>
+    /// Try to connect and print the PVE version. Returns true on success.
+    /// On failure prints a warning to stderr and returns false (callers decide the exit code).
+    /// </summary>
+    private static async Task<bool> ValidateAndPrint(PveContext ctx)
     {
         try
         {
             var client = await PveConfigManager.CreateClientAsync(ctx);
             Console.WriteLine($"Connected to {ctx.Host} — PVE version: {(await client.Version.GetAsync()).Version}");
+            return true;
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"Warning: could not connect to '{ctx.Host}': {ex.Message}");
+            Console.Error.WriteLine($"Warning: could not connect to '{ctx.Host}': {ex.Message}");
+            return false;
         }
     }
 
@@ -66,8 +72,9 @@ internal static class ConfigCommands
             {
                 PveConfigManager.UseContext(action.GetValue(argName)!);
                 Console.WriteLine($"Switched to context '{action.GetValue(argName)}'.");
+                return (int)ExitCode.Ok;
             }
-            catch (Exception ex) { Console.WriteLine($"Error: {ex.Message}"); }
+            catch (Exception ex) { return ExitCodeHelper.Fail(ex); }
         });
     }
 
@@ -132,8 +139,9 @@ internal static class ConfigCommands
                 PveConfigManager.AddContext(ctx);
                 Console.WriteLine($"Context '{ctx.Name}' saved.");
                 await ValidateAndPrint(ctx);
+                return (int)ExitCode.Ok;
             }
-            catch (Exception ex) { Console.WriteLine($"Error: {ex.Message}"); }
+            catch (Exception ex) { return ExitCodeHelper.Fail(ex); }
         });
     }
 
@@ -176,8 +184,9 @@ internal static class ConfigCommands
                 PveConfigManager.Save(config);
                 Console.WriteLine($"Context '{action.GetValue(argName)}' updated.");
                 await ValidateAndPrint(ctx);
+                return (int)ExitCode.Ok;
             }
-            catch (Exception ex) { Console.WriteLine($"Error: {ex.Message}"); }
+            catch (Exception ex) { return ExitCodeHelper.Fail(ex); }
         });
     }
 
@@ -191,8 +200,9 @@ internal static class ConfigCommands
             {
                 PveConfigManager.DeleteContext(action.GetValue(argName)!);
                 Console.WriteLine($"Context '{action.GetValue(argName)}' deleted.");
+                return (int)ExitCode.Ok;
             }
-            catch (Exception ex) { Console.WriteLine($"Error: {ex.Message}"); }
+            catch (Exception ex) { return ExitCodeHelper.Fail(ex); }
         });
     }
 
@@ -207,8 +217,9 @@ internal static class ConfigCommands
             {
                 PveConfigManager.RenameContext(action.GetValue(argOld)!, action.GetValue(argNew)!);
                 Console.WriteLine($"Context renamed to '{action.GetValue(argNew)}'.");
+                return (int)ExitCode.Ok;
             }
-            catch (Exception ex) { Console.WriteLine($"Error: {ex.Message}"); }
+            catch (Exception ex) { return ExitCodeHelper.Fail(ex); }
         });
     }
 
@@ -236,9 +247,9 @@ internal static class ConfigCommands
                     ctx = config.Contexts.FirstOrDefault(c => c.Name == name)
                             ?? throw new InvalidOperationException($"Context '{name}' not found.");
                 }
-                await ValidateAndPrint(ctx);
+                return await ValidateAndPrint(ctx) ? (int)ExitCode.Ok : (int)ExitCode.Server;
             }
-            catch (Exception ex) { Console.WriteLine($"Error: {ex.Message}"); }
+            catch (Exception ex) { return ExitCodeHelper.Fail(ex); }
         });
     }
 

--- a/src/Corsinvest.ProxmoxVE.Cli/ExitCode.cs
+++ b/src/Corsinvest.ProxmoxVE.Cli/ExitCode.cs
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: MIT
+ */
+
+namespace Corsinvest.ProxmoxVE.Cli;
+
+/// <summary>
+/// Semantic process exit codes, so scripts and CI can distinguish failure kinds.
+/// </summary>
+internal enum ExitCode
+{
+    /// <summary>Success.</summary>
+    Ok = 0,
+
+    /// <summary>Generic/unclassified error.</summary>
+    Generic = 1,
+
+    /// <summary>Authentication or configuration error (bad credentials, missing context).</summary>
+    Auth = 2,
+
+    /// <summary>Requested resource not found.</summary>
+    NotFound = 3,
+
+    /// <summary>API/server error (server unreachable, HTTP 5xx).</summary>
+    Server = 4,
+
+    /// <summary>Async task failed.</summary>
+    TaskFailed = 5,
+
+    /// <summary>Input validation error (bad argument, missing required value).</summary>
+    Validation = 6,
+}
+
+/// <summary>
+/// Helpers to report errors consistently: message to stderr, semantic exit code returned.
+/// </summary>
+internal static class ExitCodeHelper
+{
+    /// <summary>
+    /// Print an error to stderr and return the given exit code as int.
+    /// </summary>
+    public static int Fail(string message, ExitCode code = ExitCode.Generic)
+    {
+        Console.Error.WriteLine($"Error: {message}");
+        return (int)code;
+    }
+
+    /// <summary>
+    /// Print an exception to stderr and return an exit code inferred from the exception.
+    /// </summary>
+    public static int Fail(Exception ex) => Fail(ex.Message, Classify(ex));
+
+    /// <summary>
+    /// Best-effort mapping of an exception to a semantic exit code.
+    /// </summary>
+    public static ExitCode Classify(Exception ex)
+    {
+        var msg = ex.Message.ToLowerInvariant();
+
+        if (ex is UnauthorizedAccessException
+            || msg.Contains("401")
+            || msg.Contains("403")
+            || msg.Contains("unauthorized")
+            || msg.Contains("forbidden")
+            || msg.Contains("authentication")
+            || msg.Contains("permission")) { return ExitCode.Auth; }
+
+        if (ex is KeyNotFoundException
+            || msg.Contains("404")
+            || msg.Contains("not found")
+            || msg.Contains("does not exist")) { return ExitCode.NotFound; }
+
+        if (ex is ArgumentException
+            || msg.Contains("400")
+            || msg.Contains("invalid")
+            || msg.Contains("required")) { return ExitCode.Validation; }
+
+        if (ex is HttpRequestException
+            || msg.Contains("500")
+            || msg.Contains("502")
+            || msg.Contains("503")
+            || msg.Contains("connection")
+            || msg.Contains("timeout")
+            || msg.Contains("unreachable")) { return ExitCode.Server; }
+
+        return ExitCode.Generic;
+    }
+}


### PR DESCRIPTION
## Summary

Config/alias command handlers used to catch exceptions, print `Error: ...` to **stdout**, and still return **0**. Failures looked like success to scripts/CI, and error text leaked into stdout (e.g. JSON output).

- **New `ExitCode` enum + `ExitCodeHelper`** — codes: `0` ok, `1` generic, `2` auth/config, `3` not-found, `4` api/server, `5` task-failed, `6` validation. Helper writes the message to **stderr** and classifies exceptions.
- **Refactored all catch blocks** in `ConfigCommands` and `AliasCommands` to return a semantic code and print to stderr.
- **`config verify`** now exits non-zero when the connection fails (`ValidateAndPrint` returns bool). `add`/`set` stay best-effort — the context is still saved even if the post-save connectivity check fails.
- **Docs:** exit-code table in `docs/commands.md` + README feature entry.

## Test (runtime)

| Command | Before | After |
|---------|--------|-------|
| `config use nonesiste` | exit 0, error on stdout | **exit 3**, error on stderr |
| `config verify nonesiste` | exit 0 | **exit 3** |
| `config list` (ok) | exit 0 | exit 0 |

`dotnet build` clean (0 errors).