### PR TITLE
Wire --wait on aliases (was hardcoded false)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ cv4pve-cli top
 - **Direct API access** — full Proxmox VE REST API via `api get/set/create/delete`
 - **[300+ built-in aliases](#built-in-aliases)** — shortcuts for common operations (start, stop, snapshot, migrate, …)
 - **Guest auto-resolution** — use `--guest <name|id>` instead of typing node, vmtype and vmid
+- **Async task support** — add `--wait` to any command to block until the Proxmox task finishes
 - **Tab completion** — bash, zsh and PowerShell, queries the live API
 - **API schema cached locally** — refreshed automatically on PVE upgrade
 - **Scriptable** — semantic [exit codes](docs/commands.md#exit-codes), errors on stderr

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -112,6 +112,17 @@ cv4pve-cli vm-net pve1 100
 
 Built-in aliases cannot be modified or removed. User aliases live in `~/.cv4pve/cli/alias`.
 
+### Waiting for async tasks (`--wait`)
+
+Operations that start an async Proxmox task (start, stop, snapshot, backup, migrate, clone, restore, …) return a task id (UPID) immediately. Add **`--wait`** to any alias to block until the task finishes and reflect its result in the exit code:
+
+```bash
+cv4pve-cli do start vm --guest 100 --wait        # returns only when the VM has started
+cv4pve-cli do backup guest --guest 100 --storage local --wait
+```
+
+Without `--wait` the command is fire-and-forget (prints the UPID and returns). The same flag is available on `api create/set/delete`.
+
 ### Guest auto-resolution (`--guest`)
 
 Aliases whose path targets a specific guest accept `--guest <id|name>` and resolve `{node}`, `{vmid}` and `{vmtype}` automatically from `/cluster/resources`.

--- a/src/Corsinvest.ProxmoxVE.Cli/ShellCommands.cs
+++ b/src/Corsinvest.ProxmoxVE.Cli/ShellCommands.cs
@@ -298,6 +298,7 @@ internal class ShellCommands
 
             var optOutput = ApiOutputOption(cmd);
             var optVerbose = cmd.VerboseOption();
+            var optWait = cmd.AddOption<bool>(ArgWait, "Wait for the async task (UPID) to finish");
 
             cmd.TreatUnmatchedTokensAsErrors = false;
             cmd.SetAction(async (action) =>
@@ -317,7 +318,10 @@ internal class ShellCommands
                 // Reconstruct the interleaved key/value list by merging UnmatchedTokens (keys starting
                 // with "--") with the positional values that exceed the tag count (extra values).
                 var extraValues = positional.Skip(tags.Length).ToList();
-                var kvKeys = action.UnmatchedTokens.Where(t => t.StartsWith("--")).ToList();
+                // Exclude control flags (e.g. --wait) so they are not forwarded to the PVE API as parameters.
+                var kvKeys = action.UnmatchedTokens
+                                    .Where(t => t.StartsWith("--") && !string.Equals(t, ArgWait, StringComparison.OrdinalIgnoreCase))
+                                    .ToList();
                 var merged = new List<string>();
                 var valueIdx = 0;
                 foreach (var key in kvKeys)
@@ -333,7 +337,7 @@ internal class ShellCommands
                                                                            tokens[1],
                                                                            HttpVerbToMethodType(tokens[0]),
                                                                            ApiExplorerHelper.CreateParameterResource(extraParams),
-                                                                           false,
+                                                                           action.GetValue(optWait),
                                                                            action.GetValue(optOutput),
                                                                            action.GetValue(optVerbose));
                 Console.Out.Write(resultText);


### PR DESCRIPTION
## Summary

Aliases that start an async Proxmox task (`do start vm`, `create guest snapshot`, `do backup guest`, `do restore vm`, …) returned the UPID and exited immediately. `--wait` was honored only on the raw `api` path — for aliases it was **hardcoded `false`** (`ShellCommands.cs`), so lifecycle/backup operations were fire-and-forget and their exit code never reflected the task result.

- Register `--wait` as a real option on every alias command. Because System.CommandLine now claims it, it no longer leaks into `UnmatchedTokens` and is not forwarded to the PVE API as a parameter; its value is passed to `ApiExplorerHelper.ExecuteAsync` instead of the hardcoded `false`.
- Defensively exclude `--wait` from the key/value merge that builds API parameters.
- **Opt-in** (default off) to preserve existing behavior. The task-polling itself already lives in the `Api.Console` library used by `api --wait` — this only wires the flag through.
- Documented in `docs/commands.md`.

## Test

- `do start vm --help`, `do restore vm --help` (with `--yes`), `get vms --help` all show `--wait`; `--yes` and `--wait` coexist.
- `dotnet build` clean (0 errors).

## Notes

Default stays off because aliases are generic (`get`/`create`/`delete`); a read alias has no task to wait for. A smart per-verb default (wait on POST that returns a UPID) can come later.