### PR TITLE
Add task subcommand (list/show/wait/log --follow/stop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ cv4pve-cli top
 - **Direct API access** — full Proxmox VE REST API via `api get/set/create/delete`
 - **[300+ built-in aliases](#built-in-aliases)** — shortcuts for common operations (start, stop, snapshot, migrate, …)
 - **Guest auto-resolution** — use `--guest <name|id>` instead of typing node, vmtype and vmid
-- **Async task support** — add `--wait` to any command to block until the Proxmox task finishes
+- **Async task support** — add `--wait` to any command, or use `task log --follow` to tail a running task
 - **Tab completion** — bash, zsh and PowerShell, queries the live API
 - **API schema cached locally** — refreshed automatically on PVE upgrade
 - **Scriptable** — semantic [exit codes](docs/commands.md#exit-codes), errors on stderr

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -143,6 +143,28 @@ The three special placeholders:
 
 ---
 
+## task — async task management (UPID)
+
+Follow, wait on, or inspect Proxmox background tasks by their UPID. The node is decoded from the UPID automatically.
+
+```
+cv4pve-cli task list [--node <node>] [-o <format>]   # recent tasks (cluster-wide or per node)
+cv4pve-cli task show <upid>                           # status + exit status of a task
+cv4pve-cli task wait <upid> [--timeout <seconds>]     # block until the task finishes
+cv4pve-cli task log  <upid> [--follow] [--limit <n>] [--interval <s>]  # print the task log; --follow tails it live (polls every 2s by default)
+cv4pve-cli task stop <upid> --yes                     # stop (kill) a running task
+```
+
+```bash
+# start a backup without waiting, then follow its log
+cv4pve-cli do backup guest --guest 100 --storage local        # prints the UPID
+cv4pve-cli task log 'UPID:pve1:...:vzdump:100:root@pam:' --follow
+```
+
+Exit code reflects the task result: `0` if the task finished OK, `5` (task-failed) otherwise.
+
+---
+
 ## completion — shell tab completion
 
 Registered automatically on first run for bash, zsh and PowerShell; queries the live API for node names, VM IDs, parameter names.

--- a/src/Corsinvest.ProxmoxVE.Cli/Program.cs
+++ b/src/Corsinvest.ProxmoxVE.Cli/Program.cs
@@ -17,6 +17,7 @@ app.AddDryRunOption();
 var loggerFactory = ConsoleHelper.CreateLoggerFactory<Program>(app.GetLogLevelFromDebug());
 
 ShellCommands.CreateCommands(app, loggerFactory);
+app.AddTaskCommands();
 SpecialCommands.AddCommands(app);
 CompletionHelper.AddCompleteCommand(app);
 CompletionHelper.EnsureRegistered();

--- a/src/Corsinvest.ProxmoxVE.Cli/ShellCommands.cs
+++ b/src/Corsinvest.ProxmoxVE.Cli/ShellCommands.cs
@@ -57,7 +57,7 @@ internal class ShellCommands
     /// Get PveClient from context file — singleton per process to avoid multiple logins.
     /// </summary>
     private static PveClient? _cachedClient;
-    private static async Task<PveClient> GetClientAsync()
+    internal static async Task<PveClient> GetClientAsync()
     {
         if (_cachedClient != null) { return _cachedClient; }
         var context = PveConfigManager.GetCurrentContext()

--- a/src/Corsinvest.ProxmoxVE.Cli/TaskCommands.cs
+++ b/src/Corsinvest.ProxmoxVE.Cli/TaskCommands.cs
@@ -1,0 +1,195 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: MIT
+ */
+
+using System.CommandLine;
+using Corsinvest.ProxmoxVE.Api;
+using Corsinvest.ProxmoxVE.Api.Console.Helpers;
+using Corsinvest.ProxmoxVE.Api.Extension;
+using Corsinvest.ProxmoxVE.Api.Shared.Utils;
+
+namespace Corsinvest.ProxmoxVE.Cli;
+
+/// <summary>
+/// Task subcommands (list, show, wait, log, stop) for async Proxmox tasks (UPID).
+/// </summary>
+internal static class TaskCommands
+{
+    private static readonly string[] ListColumns = ["upid", "type", "id", "status", "node", "user"];
+
+    public static void AddTaskCommands(this RootCommand root)
+    {
+        var cmd = root.AddCommand("task", "Manage async tasks (UPID)");
+        CmdList(cmd);
+        CmdShow(cmd);
+        CmdWait(cmd);
+        CmdLog(cmd);
+        CmdStop(cmd);
+    }
+
+    private static Argument<string> AddUpidArgument(Command cmd)
+    {
+        var arg = cmd.AddArgument<string>("upid", "Task identifier (UPID)");
+        arg.HelpName = "upid";
+        return arg;
+    }
+
+    private static void CmdList(Command parent)
+    {
+        var cmd = parent.AddCommand("list", "List recent tasks");
+        var optNode = cmd.AddOption<string?>("--node", "Limit to a specific node (default: whole cluster)");
+        var optOutput = cmd.TableOutputOption();
+        cmd.SetAction(async (action) =>
+        {
+            try
+            {
+                var client = await ShellCommands.GetClientAsync();
+                var node = action.GetValue(optNode);
+                var result = string.IsNullOrWhiteSpace(node)
+                                ? await client.Cluster.Tasks.Tasks()
+                                : await client.Nodes[node].Tasks.NodeTasks();
+
+                var rows = result.ToEnumerable()
+                                 .Select(t => ListColumns.Select(c => Field((object)t, c)).ToArray())
+                                 .ToArray();
+                Console.Out.WriteLine(TableGenerator.To(ListColumns, rows, action.GetValue(optOutput)));
+                return (int)ExitCode.Ok;
+            }
+            catch (Exception ex) { return ExitCodeHelper.Fail(ex); }
+        });
+    }
+
+    private static void CmdShow(Command parent)
+    {
+        var cmd = parent.AddCommand("show", "Show status of a task");
+        var argUpid = AddUpidArgument(cmd);
+        cmd.SetAction(async (action) =>
+        {
+            try
+            {
+                var client = await ShellCommands.GetClientAsync();
+                var upid = action.GetValue(argUpid)!;
+                var status = await client.Nodes[PveClientBase.GetNodeFromTask(upid)].Tasks[upid].Status.GetAsync();
+
+                Console.Out.WriteLine($"UPID:       {status.Upid}");
+                Console.Out.WriteLine($"Node:       {status.Node}");
+                Console.Out.WriteLine($"Type:       {status.Type}");
+                Console.Out.WriteLine($"Id:         {status.Id}");
+                Console.Out.WriteLine($"User:       {status.User}");
+                Console.Out.WriteLine($"Status:     {status.Status}");
+                Console.Out.WriteLine($"ExitStatus: {status.ExitStatus}");
+
+                // running → 0; finished OK → 0; finished with error → task-failed
+                if (status.Status != "running" && !IsOk(status.ExitStatus)) { return (int)ExitCode.TaskFailed; }
+                return (int)ExitCode.Ok;
+            }
+            catch (Exception ex) { return ExitCodeHelper.Fail(ex); }
+        });
+    }
+
+    private static void CmdWait(Command parent)
+    {
+        var cmd = parent.AddCommand("wait", "Wait for a task to finish");
+        var argUpid = AddUpidArgument(cmd);
+        var optTimeout = cmd.AddOption<int>("--timeout", "Timeout in seconds");
+        optTimeout.DefaultValueFactory = (_) => 300;
+        cmd.SetAction(async (action) =>
+        {
+            try
+            {
+                var client = await ShellCommands.GetClientAsync();
+                var upid = action.GetValue(argUpid)!;
+                var timeoutMs = action.GetValue(optTimeout) * 1000L;
+
+                var finished = await client.WaitForTaskToFinishAsync(upid, wait: 2000, timeout: timeoutMs);
+                if (!finished)
+                {
+                    Console.Error.WriteLine("Error: timeout waiting for task to finish.");
+                    return (int)ExitCode.TaskFailed;
+                }
+
+                var exit = await client.GetExitStatusTaskAsync(upid);
+                Console.Out.WriteLine(exit);
+                return IsOk(exit) ? (int)ExitCode.Ok : (int)ExitCode.TaskFailed;
+            }
+            catch (Exception ex) { return ExitCodeHelper.Fail(ex); }
+        });
+    }
+
+    private static void CmdLog(Command parent)
+    {
+        var cmd = parent.AddCommand("log", "Print the log of a task");
+        var argUpid = AddUpidArgument(cmd);
+        var optFollow = cmd.AddOption<bool>("--follow|-f", "Follow the log until the task finishes");
+        var optLimit = cmd.AddOption<int>("--limit", "Max lines per poll");
+        optLimit.DefaultValueFactory = (_) => 500;
+        var optInterval = cmd.AddOption<int>("--interval", "Seconds between polls when following (min: 1)");
+        optInterval.DefaultValueFactory = (_) => 2;
+        cmd.SetAction(async (action) =>
+        {
+            try
+            {
+                var client = await ShellCommands.GetClientAsync();
+                var upid = action.GetValue(argUpid)!;
+                var follow = action.GetValue(optFollow);
+                var limit = action.GetValue(optLimit);
+                var intervalMs = Math.Max(1, action.GetValue(optInterval)) * 1000;
+
+                var item = client.Nodes[PveClientBase.GetNodeFromTask(upid)].Tasks[upid];
+                var start = 0;
+
+                while (true)
+                {
+                    // Read status BEFORE draining the log, so the final poll still
+                    // captures lines written between the last poll and task end.
+                    var status = await item.Status.GetAsync();
+                    var running = status.Status == "running";
+
+                    var lines = (await item.Log.GetAsync(limit, start)).ToList();
+                    foreach (var line in lines) { Console.Out.WriteLine(line); }
+                    start += lines.Count;
+
+                    if (!running || !follow) { return running || IsOk(status.ExitStatus) ? (int)ExitCode.Ok : (int)ExitCode.TaskFailed; }
+                    await Task.Delay(intervalMs);
+                }
+            }
+            catch (Exception ex) { return ExitCodeHelper.Fail(ex); }
+        });
+    }
+
+    private static void CmdStop(Command parent)
+    {
+        var cmd = parent.AddCommand("stop", "Stop (kill) a running task");
+        var argUpid = AddUpidArgument(cmd);
+        var optYes = cmd.AddOption<bool>("--yes|-y", "Confirm stopping the task");
+        cmd.SetAction(async (action) =>
+        {
+            try
+            {
+                if (!action.GetValue(optYes))
+                {
+                    Console.Error.WriteLine("Error: stopping a task is disruptive. Use --yes / -y to confirm.");
+                    return (int)ExitCode.Validation;
+                }
+                var client = await ShellCommands.GetClientAsync();
+                var upid = action.GetValue(argUpid)!;
+                await client.Nodes[PveClientBase.GetNodeFromTask(upid)].Tasks[upid].StopTask();
+                Console.Out.WriteLine($"Task '{upid}' stop requested.");
+                return (int)ExitCode.Ok;
+            }
+            catch (Exception ex) { return ExitCodeHelper.Fail(ex); }
+        });
+    }
+
+    // PVE exitstatus is "OK" or "OK: ..." on success; anything else is a failure.
+    private static bool IsOk(string? exitStatus)
+        => !string.IsNullOrWhiteSpace(exitStatus)
+           && exitStatus.StartsWith("OK", StringComparison.OrdinalIgnoreCase);
+
+    // Read a property from a dynamic task row (ExpandoObject), empty string if absent.
+    private static object Field(object row, string name)
+        => row is IDictionary<string, object> dict && dict.TryGetValue(name, out var v) && v != null
+                ? v
+                : string.Empty;
+}


### PR DESCRIPTION
## Summary

Adds a `task` command tree to inspect and follow async Proxmox tasks by UPID — complements the fire-and-forget alias path and the `--wait` flag (PR #14).

```
task list [--node] [-o <fmt>]          recent tasks, cluster-wide or per node
task show <upid>                       status + exit status
task wait <upid> [--timeout <s>]       block until finished (default 300s)
task log  <upid> [--follow] [--limit <n>] [--interval <s>]   print / tail the log
task stop <upid> --yes                 kill a running task
```

- **`task log --follow`** tails the log like `tail -f`: a line cursor prints only new lines, and it reads the task **status before draining the log** so lines written between the last poll and task end aren't lost. Polls every **2s by default** (`--interval`, min 1s) to avoid hammering the API.
- **Exit codes are semantic** (PR #13): `5` (task-failed) when the task ends with a non-`OK` exitstatus.

## Reuse (no library changes)

- `PveClientBase.GetNodeFromTask(upid)` — decodes the node from the UPID.
- `Nodes[node].Tasks[upid].Log.GetAsync()` / `.Status.GetAsync()` — decoded log lines + typed `NodeTaskStatus`.
- `WaitForTaskToFinishAsync` — the polling wait.
- Exposed `ShellCommands.GetClientAsync` as `internal`.

## Test

- `task --help` lists list/show/wait/log/stop; `task log --help` shows `--follow`, `--limit [default: 500]`, `--interval [default: 2]`; `task wait --help` shows `--timeout [default: 300]`.
- `dotnet build` clean (0 errors).

Documented in README + `docs/commands.md`.